### PR TITLE
알림 권한 허용 앱 메인으로 이동

### DIFF
--- a/LittleHiker Watch App/LocalNotifications.swift
+++ b/LittleHiker Watch App/LocalNotifications.swift
@@ -16,7 +16,7 @@ final class LocalNotifications: NSObject, ObservableObject {
     var tipsBlockCount: Int = 0
     @Published var isTipsBlocked: Bool = false
     var warningBlockCount: Int = 0
-
+    
     private let tips: [String] = [
         "너무 무리하면 무릎의 충격을 흡수하는 반월상 연골이 찢어질 수 있어요!",
         "적정 하산시간은 등산시간의 2배입니다.",
@@ -36,48 +36,61 @@ final class LocalNotifications: NSObject, ObservableObject {
     var tipsBlockBufferBatch: Int = 3
     var warningBlockBufferBatch: Int = 3
     
-
+    
+    override init() {
+        super.init()
+        requestAuthorization()
+    }
+    
+    func requestAuthorization() {
+        let current = UNUserNotificationCenter.current()
+        current.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            if granted {
+                print("알림 권한이 허용되었습니다.")
+            } else {
+                print("알림 권한이 허용되지 않았습니다.")
+            }
+        }
+    }
+    
     func schedule() {
         let current = UNUserNotificationCenter.current()
-        current.requestAuthorization(options: [.alert, .sound]) {[weak self] granted, error in
-            guard let self = self else { return }
-            
-            if granted {
-                print("허용되었습니다")
-                if tipsBlockCount != 0 { return }
-                if isTipsBlocked == true { return }
-                tipsBlockCount += 60*tipsBlockBufferBatch // 3분동안의 알림 버퍼 적용
-                current.removeAllPendingNotificationRequests()
-                let content = UNMutableNotificationContent()
-                content.title = "잠깐"
-                content.subtitle = "다람상식"
-                content.body = tips[Int.random(in: 0..<tips.count)]
-                content.categoryIdentifier = "다람상식"
-                
-//                let trigger: UNTimeIntervalNotificationTrigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
-                //UserNoitificationAppDelegate에 나머지 설정 있음
-                let action1 = UNNotificationAction(identifier:"30분_끄기",
-                                                  title: "30분동안 다람상식 끄기",
-                                                  options: [])
-                let action2 = UNNotificationAction(identifier: "계속_끄기",
-                                                  title: "계속 다람상식 끄기",
-                                                  options: [])
-                let category = UNNotificationCategory(identifier: "다람상식",
-                                                      actions: [action1, action2],
-                                                      intentIdentifiers: [],
-                                                      options: [])
-                UNUserNotificationCenter.current().setNotificationCategories([category])
-                let request = UNNotificationRequest(identifier: UUID().uuidString,
-                                                    content: content,
-                                                    trigger: nil)
-                
-                DispatchQueue.global().async{
-                    current.add(request)
+        current.getNotificationSettings { settings in
+            if settings.authorizationStatus == .authorized {
+                DispatchQueue.main.async {
+                    if self.tipsBlockCount != 0 { return }
+                    if self.isTipsBlocked { return }
+                    self.tipsBlockCount += 60 * self.tipsBlockBufferBatch // 3분동안의 알림 버퍼 적용
+                    current.removeAllPendingNotificationRequests()
+                    let content = UNMutableNotificationContent()
+                    content.title = "잠깐"
+                    content.subtitle = "다람상식"
+                    content.body = self.tips.randomElement() ?? ""
+                    content.categoryIdentifier = "다람상식"
+                    
+                    //                let trigger: UNTimeIntervalNotificationTrigger = UNTimeIntervalNotificationTrigger(timeInterval: 0.1, repeats: false)
+                    //UserNoitificationAppDelegate에 나머지 설정 있음
+                    let action1 = UNNotificationAction(identifier:"30분_끄기",
+                                                       title: "30분동안 다람상식 끄기",
+                                                       options: [])
+                    let action2 = UNNotificationAction(identifier: "계속_끄기",
+                                                       title: "계속 다람상식 끄기",
+                                                       options: [])
+                    let category = UNNotificationCategory(identifier: "다람상식",
+                                                          actions: [action1, action2],
+                                                          intentIdentifiers: [],
+                                                          options: [])
+                    UNUserNotificationCenter.current().setNotificationCategories([category])
+                    let request = UNNotificationRequest(identifier: UUID().uuidString,
+                                                        content: content,
+                                                        trigger: nil)
+                    
+                    DispatchQueue.global().async{
+                        current.add(request)
+                    }
                 }
-
-//                }
             } else {
-                print("로컬 알림 권한이 허용되지 않았습니다")
+                print("알림 권한이 허용되지 않았습니다.")
             }
         }
     }
@@ -85,32 +98,39 @@ final class LocalNotifications: NSObject, ObservableObject {
     
     func schedule2() {
         let current = UNUserNotificationCenter.current()
-        current.requestAuthorization(options: [.alert, .sound]) {[weak self] granted, error in
-            guard let self = self else { return }
-            
-            if granted {
-                if warningBlockCount != 0 { return }
-                if isTipsBlocked == true { return }
-                warningBlockCount += 60*warningBlockBufferBatch //3분동안의 알림 버퍼 적용
-                current.removeAllPendingNotificationRequests()
-                print("허용되었습니다")
-                let content = UNMutableNotificationContent()
-                content.title = "잠깐"
-                content.subtitle = "다람이 missing"
-                content.body = warnings[Int.random(in: 0..<warnings.count)]
-                content.categoryIdentifier = self.categoryIdentifier
+//        current.requestAuthorization(options: [.alert, .sound]) {[weak self] granted, error in
+//            guard let self = self else { return }
+//            
+//            if granted {
+//                if warningBlockCount != 0 { return }
+//                if isTipsBlocked == true { return }
+//                warningBlockCount += 60*warningBlockBufferBatch //3분동안의 알림 버퍼 적용
                 
-                let request = UNNotificationRequest(identifier: UUID().uuidString,
-                                                    content: content,
-                                                    trigger: nil)
-                DispatchQueue.global().async{
-                    current.add(request)
-                }
-
+                current.getNotificationSettings { settings in
+                    if settings.authorizationStatus == .authorized {
+                        DispatchQueue.main.async {
+                            if self.tipsBlockCount != 0 { return }
+                            if self.isTipsBlocked { return }
+                            self.tipsBlockCount += 60 * self.tipsBlockBufferBatch // 3분동안의 알림 버퍼 적용
+                            
+                            current.removeAllPendingNotificationRequests()
+                            print("허용되었습니다")
+                            let content = UNMutableNotificationContent()
+                            content.title = "잠깐"
+                            content.subtitle = "다람이 missing"
+                            content.body = self.tips.randomElement() ?? ""
+                            content.categoryIdentifier = self.categoryIdentifier
+                            
+                            let request = UNNotificationRequest(identifier: UUID().uuidString,
+                                                                content: content,
+                                                                trigger: nil)
+                            DispatchQueue.global().async{
+                                current.add(request)
+                            }
+                        }
             } else {
                 print("로컬 알림 권한이 허용되지 않았습니다")
             }
-            
         }
     }
     
@@ -138,7 +158,7 @@ final class LocalNotifications: NSObject, ObservableObject {
             self.turnOnTips()
         }
     }
-
+    
     
     func turnOnTips(){
         tipsBlockCount = 0
@@ -149,7 +169,7 @@ final class LocalNotifications: NSObject, ObservableObject {
     func decreaseWarningBlockCount(){
         if warningBlockCount > 0 {
             warningBlockCount -= 1
-       }
+        }
     }
     
     func toggleTipsManually(){
@@ -160,7 +180,7 @@ final class LocalNotifications: NSObject, ObservableObject {
         }
         isTipsBlocked.toggle()
     }
-
+    
 }
 
 let sharedLocalNotifications = LocalNotifications.shared


### PR DESCRIPTION
- 알림 권한을 앱 설치 최초에 동의할 수 있도록 변경했어요.
- WatchMainView에서 LocalNotifications.shared 를 참조하는 구조로 되어 있어서 알림이 올 때 알림 권한 동의하는 로직만 따로 실행될 수 있도록 앞쪽으로 분리했습니다.