### PR TITLE
알림 트리거 기준 하향 (redzone 지속시간 5초)

### DIFF
--- a/LittleHiker Watch App/Manager/ImpulseManager.swift
+++ b/LittleHiker Watch App/Manager/ImpulseManager.swift
@@ -190,7 +190,7 @@ class ImpulseManager: NSObject, ObservableObject {
     }
     
     func stayedInRedZoneForTooLong() -> Bool {
-        if 15 <= redZoneCount {
+        if 5 <= redZoneCount {
             return true
         }
         return false


### PR DESCRIPTION
붉은색 구간에 `15초`동안 머물렀을 때 경고 보내기 → 붉은색 구간에 `5초`동안 머물렀을 때 경고 보내기로 로직을 수정하였습니다.