### PR TITLE
HikingRecord 조회 로직 추가, HK 저장 로직 디버깅

### DIFF
--- a/LittleHiker Watch App/View/WatchButtonView.swift
+++ b/LittleHiker Watch App/View/WatchButtonView.swift
@@ -121,8 +121,10 @@ struct WatchButtonView: View {
                     //TODO: SwiftData를 저장하자
                     
                     //워크아웃 활동 종료 후 impulseRate 데이터 전송
-                    viewModel.healthKitManager.endHikingWorkout()
-                    viewModel.endHiking()
+                    Task{
+                        await viewModel.healthKitManager.endHikingWorkout()
+                        viewModel.endHiking()
+                    }
                     
                     viewModel.stop()
                     viewModel.status = .complete

--- a/LittleHiker Watch App/ViewModel/HikingViewModel.swift
+++ b/LittleHiker Watch App/ViewModel/HikingViewModel.swift
@@ -153,7 +153,8 @@ class HikingViewModel: NSObject, CLLocationManagerDelegate, ObservableObject {
                 }
                 
                 //uuidString이 호출때마다 uuid를 생성해서 보내는 데이터 uuid 통일이 안되서 한번만 생성 후 사용
-                let uuid = self.healthKitManager.workoutSession?.currentActivity.uuid.uuidString ?? ""
+                let uuid = self.healthKitManager.assignedUUIDString ?? ""
+                print("after end string : \(uuid)")
                 if uuid != "" {
                     //산행으로 만들어진 SummaryData
                     let customComplementaryHikingData = self.createCustomComplementaryHikingData(

--- a/LittleHiker.xcodeproj/project.pbxproj
+++ b/LittleHiker.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		1A43DFB52BFCAD9F00E62BA6 /* ImpulseManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImpulseManager.swift; sourceTree = "<group>"; };
 		1A43DFB72BFCADAD00E62BA6 /* TimeManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeManager.swift; sourceTree = "<group>"; };
 		1A8DBE9D2BFE2CB600C3BA92 /* PushNotificationPayload.apns */ = {isa = PBXFileReference; lastKnownFileType = text; path = PushNotificationPayload.apns; sourceTree = "<group>"; };
+		1AE1CA922CFDE88D00EE0CCC /* LittleHiker.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = LittleHiker.entitlements; sourceTree = "<group>"; };
 		1AEB6D872BFF56B200B77565 /* LocalNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalNotifications.swift; sourceTree = "<group>"; };
 		1EF68A6A2C0DDC2200DC2823 /* LittleHiker-Watch-App-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "LittleHiker-Watch-App-Info.plist"; sourceTree = SOURCE_ROOT; };
 		EE5068AB2CA3BB7300F5441F /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
@@ -221,6 +222,7 @@
 		1A43DF822BFCAC9A00E62BA6 /* LittleHiker */ = {
 			isa = PBXGroup;
 			children = (
+				1AE1CA922CFDE88D00EE0CCC /* LittleHiker.entitlements */,
 				1A35BB4D2C3F63B600891AC6 /* ViewModel */,
 				1A35BB4C2C3F63A400891AC6 /* Model */,
 				022338BD2C800DA000FC1427 /* Manager */,
@@ -677,6 +679,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = LittleHiker/LittleHiker.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LittleHiker/Preview Content\"";
@@ -710,6 +713,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = LittleHiker/LittleHiker.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"LittleHiker/Preview Content\"";

--- a/LittleHiker/LittleHiker.entitlements
+++ b/LittleHiker/LittleHiker.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.healthkit</key>
+	<true/>
+</dict>
+</plist>

--- a/LittleHiker/Manager/HealthKitManager+IOS.swift
+++ b/LittleHiker/Manager/HealthKitManager+IOS.swift
@@ -12,6 +12,20 @@ class HealthKitManager {
     let dataSource: DataSource = DataSource.shared // SwiftData + MVVM을 위해 필요한 변수
     let healthStore = HKHealthStore()
     
+    func updateCurrentRecord(currentRecord: HikingRecord) {
+        fetchWorkoutByUUID(uuid: currentRecord.id) { workout in
+            guard let workout = workout else {
+                print("No workout found with UUID: \(currentRecord.id)")
+                return
+            }
+            
+            DispatchQueue.main.async {
+                currentRecord.startDateTime = workout.startDate
+                currentRecord.endDateTime = workout.endDate
+            }
+        }
+    }
+    
     func saveWorkoutData(uuid: UUID) {
         fetchWorkoutByUUID(uuid: uuid) { workout in
             guard let workout = workout else {
@@ -34,11 +48,16 @@ class HealthKitManager {
 //            return
 //        }
         
+        
         // UUID로 검색하는 Predicate
         let predicate = HKQuery.predicateForObject(with: uuid)
         
         // Workout을 쿼리
         let workoutQuery = HKSampleQuery(sampleType: HKObjectType.workoutType(), predicate: predicate, limit: 1, sortDescriptors: nil) { (query, samples, error) in
+            if samples != nil {
+                print("Printing workout samples")
+                print(samples)
+            }
             
             if let error = error {
                 print("Error fetching workout: \(error.localizedDescription)")

--- a/LittleHiker/View/PhoneDetailView.swift
+++ b/LittleHiker/View/PhoneDetailView.swift
@@ -150,8 +150,11 @@ struct PhoneDetailView: View {
             }
             
         }
-        
         .padding()
+        .onAppear{
+            let healthkitManager = HealthKitManager()
+            healthkitManager.updateCurrentRecord(currentRecord: record)
+        }
     }
 }
 


### PR DESCRIPTION
## 관련 로직
- #111 

## iOS: 조회 로직 추가
-  DetailView에서 onAppear상에서 uuid 기준으로 HK Sample 조회 후 해당 HikingRecord 정보를 업데이트합니다.

## watchOS: HK 저장 로직 디버깅
- 기존 로직은 HK 데이터베이스에 저장되기 전에 workout의 UUID를 가져오면서 valid하지 않은  UUID를 통해 모델 객체를 생성하게 되어 이후 HK Query를 통해 HK 데이터에 접근할 수 없는 문제가 있었습니다. 이를 해결하고자 세션 정보를 헬스킷에 저장 후에 uuid 접근하도록 변경하였습니다.