### PR TITLE
등산 시간 기록 관련 EdgeCase 처리

### DIFF
--- a/LittleHiker Watch App/View/WatchButtonView.swift
+++ b/LittleHiker Watch App/View/WatchButtonView.swift
@@ -111,6 +111,12 @@ struct WatchButtonView: View {
                     //1. 버튼을 누르면 타이머를 멈춘다
                     timeManager.pauseStopWatch()
                     
+                    
+                    //hikingMode에서 바로 종료 버튼을 눌렀을 경우 등산 시간 기록이 안되어 있으므로 edgeCase 처리
+                    if viewModel.status == .hiking || viewModel.status == .hikingPause {
+                        timeManager.setAscendingDuration()
+                    }
+                    
                     //전체산행시간에서 등산시간을 뺀 하산시간이 계산됨
                     timeManager.setDescendingDuration()
                     


### PR DESCRIPTION
- #124 

## 문제상황
등산 모드에서 정상 버튼을 누르지 않고 바로 하산 버튼을 눌렀을 때 등산 시간이 기록되지 않는 문제가 있었습니다. 마찬가지로 등산모드에서 바로 종료 버튼을 눌렀을 때 등산 시간이 기록되지 않는 문제가 있습니다.

## 변경사항
각각의 엣지케이스 처리 로직을 버튼의 action 내부에 추가했습니다.